### PR TITLE
Make APIERServerError save the parent exception as a self.parent parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-cd-apier"
-version = "1.0.0"
+version = "1.0.1"
 description = "ci-cd-APIer -- Flask-like API framework for GitLab CI/CD pipelines"
 authors = [
     { name = "Adam Hlavacek", email = "git@adamhlavacek.com" }

--- a/src/ci_cd_apier/apier.py
+++ b/src/ci_cd_apier/apier.py
@@ -36,6 +36,7 @@ class APIERServerError(Exception):
         super().__init__(message, parent)
         self.request_id = request_id
         self.request_age_public_key = request_age_public_key
+        self.parent = parent
 
 
 class APIER:


### PR DESCRIPTION
Add `self.parent` attribute to `APIERServerError` class to save the parent exception.

* Modify `src/ci_cd_apier/apier.py` to include `self.parent = parent` in the `__init__` method of the `APIERServerError` class.
* Bump version in `pyproject.toml` from 1.0.0 to 1.0.1.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/esoadamo/ci-cd-apier/pull/1?shareId=a0468904-3ce4-4f66-b63f-2626ef3d79d7).